### PR TITLE
Use "regular" RTK queries, instead of manually fired "lazy" ones

### DIFF
--- a/src/AdminApp.test.tsx
+++ b/src/AdminApp.test.tsx
@@ -6,7 +6,7 @@ import { loadingDone, renderWithProviders } from "./utils/test-utils"
 beforeEach(() => window.localStorage.clear())
 
 test("App should have correct initial render", async () => {
-  renderWithProviders(<AdminApp />)
+  renderWithProviders(<AdminApp />, { preloadShadow: true })
   await loadingDone()
 
   expect(screen.getByText("111111")).toBeInTheDocument()

--- a/src/AdminApp.tsx
+++ b/src/AdminApp.tsx
@@ -2,14 +2,11 @@ import { AppShell, Center, Group } from "@mantine/core"
 
 import { AdminHunt } from "./features/hunt/admin/AdminHunt"
 import { ThemeToggle } from "./features/theme/ThemeToggle"
-import { useLazyGetHuntQuery, useLazyGetShadowQuery } from "./services/api"
+import { useGetHuntQuery, useGetShadowQuery } from "./services/api"
 
 const AdminApp = () => {
-  const [trigger, { data: hunt, isLoading }] = useLazyGetHuntQuery()
-  if (!hunt && !isLoading) void trigger(undefined)
-  const [shadowTrigger, { data: shadow, isLoading: shadowLoading }] =
-    useLazyGetShadowQuery()
-  if (!shadow && !shadowLoading) void shadowTrigger(undefined)
+  const { data: hunt, isLoading } = useGetHuntQuery(undefined)
+  const { data: shadow } = useGetShadowQuery(undefined)
 
   return (
     <AppShell header={{ height: 48 }}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { Hunt } from "./features/hunt/Hunt"
 import { ResetControl } from "./features/hunt/ResetControl"
 import { huntSlice } from "./features/hunt/huntSlice"
 import { ScanControl } from "./features/scan/ScanControl"
-import { useLazyGetHuntQuery } from "./services/api"
+import { useGetHuntQuery } from "./services/api"
 
 import type { Hunt as HuntData } from "./features/hunt/lib"
 
@@ -38,8 +38,7 @@ const App = ({
 }: {
   transitionDuration?: number
 }) => {
-  const [trigger, { data: hunt, isLoading, error }] = useLazyGetHuntQuery()
-  if (!hunt && !isLoading) void trigger(undefined)
+  const { data: hunt, isLoading, error } = useGetHuntQuery(undefined)
   const done = useAppSelector(huntSlice.selectors.selectComplete)
 
   return (
@@ -58,8 +57,8 @@ const App = ({
               element={
                 isLoading ? (
                   "Loading..."
-                ) : error || !hunt ? (
-                  `Error: ${error ? JSON.stringify(error) : /* v8 ignore next */ "General Failure"}`
+                ) : /* v8 ignore next */ error || !hunt ? (
+                  `Error: ${error ? JSON.stringify(error) : "General Failure"}`
                 ) : (
                   <Hunt hunt={hunt} />
                 )

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -27,4 +27,4 @@ export const api = createApi({
   }),
 })
 
-export const { useLazyGetHuntQuery, useLazyGetShadowQuery } = api
+export const { useGetHuntQuery, useGetShadowQuery } = api


### PR DESCRIPTION
The switch to lazy queries was driven by the need to test, but the ApiPreloader component is a better (test-only) way to do it. This works because both flavors of query share endpoint caches.